### PR TITLE
2.2.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,13 +8,12 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     types:
       - closed
 
 jobs:
   test:
-    # Removemos a restrição de "merged == true" porque agora o push direto também dispara
-    # E garantimos que ele rode se for um PR fechado OU um push direto
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.0
+- Add missing dart docs to get 100% covarage of the dart docs in pub score (before was 91.5%)
+- Generate dart doc api
+- Add missing tests and get 100% tests coverage (before was 89%)
+- Handle errors to `MinProvider.read` and `.watch`
+
 # 2.1.7
 - Remove dart docs in files that not more library
 - Generate dart doc api

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.6"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:

--- a/lib/min_extensions.dart
+++ b/lib/min_extensions.dart
@@ -1,1 +1,4 @@
+/// Provides extensions for [BuildContext] to simplify state access and management.
+library min_extensions;
+
 export 'src/extensions/min_provider_extensions.dart';

--- a/lib/min_notifiers.dart
+++ b/lib/min_notifiers.dart
@@ -1,1 +1,4 @@
+/// Defines the notifier classes and base state management logic for the package.
+library min_notifiers;
+
 export 'src/state/min_notifier.dart';

--- a/lib/min_observers.dart
+++ b/lib/min_observers.dart
@@ -1,1 +1,4 @@
+/// Contains the observable patterns and reactive utilities for state updates.
+library min_observers;
+
 export 'src/observers/min_app_lifecycle.dart';

--- a/lib/min_props.dart
+++ b/lib/min_props.dart
@@ -1,1 +1,4 @@
+/// Defines property-based state management tools and configurations.
+library min_props;
+
 export 'src/state/min_props.dart';

--- a/lib/min_providers.dart
+++ b/lib/min_providers.dart
@@ -1,2 +1,5 @@
-export 'src/providers/min_multi_provider.dart';
+/// Provides the core Provider components used to inject state into the widget tree.
+library min_providers;
+
 export 'src/providers/min_provider.dart';
+export 'src/providers/min_multi_provider.dart';

--- a/lib/min_services.dart
+++ b/lib/min_services.dart
@@ -1,1 +1,4 @@
+/// Contains utility services and architectural helpers for your application.
+library min_services;
+
 export 'src/services/min_service.dart';

--- a/lib/min_widgets.dart
+++ b/lib/min_widgets.dart
@@ -1,2 +1,5 @@
+/// Provides the core widgets required for reacting to state changes and rebuilding the UI.
+library min_widgets;
+
 export 'src/widgets/min_selector.dart';
 export 'src/widgets/min_widget.dart';

--- a/lib/src/observers/min_app_lifecycle.dart
+++ b/lib/src/observers/min_app_lifecycle.dart
@@ -33,10 +33,6 @@ mixin class AppLifecycleMixin implements WidgetsBindingObserver {
   // App Lifecycle Callbacks
   // ---------------------------------------------------------------------------
 
-  /// Creates a new instance of [AppLifecycleMixin] to observe
-  /// Flutter's application lifecycle states.
-  AppLifecycleMixin();
-
   /// Called when the application is visible and responding to user input.
   ///
   /// Corresponds to [AppLifecycleState.resumed].

--- a/lib/src/providers/min_provider.dart
+++ b/lib/src/providers/min_provider.dart
@@ -46,8 +46,14 @@ class MinProvider<T extends ChangeNotifier> extends StatefulWidget {
   static T watch<T extends ChangeNotifier>(BuildContext context) {
     final inherited =
         context.dependOnInheritedWidgetOfExactType<MinInherited<T>>();
-    assert(inherited != null, 'No MinProvider<$T> found in context.');
-    return inherited!.notifier!;
+
+    if (inherited == null) {
+      throw FlutterError(
+        'MinProvider<$T> was not found in the current context.\n'
+        'Make sure MinProvider is positioned above this widget in the tree.',
+      );
+    }
+    return inherited.notifier!;
   }
 
   /// Accesses the controller without subscribing to changes.
@@ -55,8 +61,15 @@ class MinProvider<T extends ChangeNotifier> extends StatefulWidget {
   static T read<T extends ChangeNotifier>(BuildContext context) {
     final element =
         context.getElementForInheritedWidgetOfExactType<MinInherited<T>>();
-    assert(element != null, 'No MinProvider<$T> found in context.');
-    final inherited = element!.widget as MinInherited<T>;
+
+    if (element == null) {
+      throw FlutterError(
+        'MinProvider<$T> was not found in the current context.\n'
+        'Make sure MinProvider is positioned above this widget in the tree.',
+      );
+    }
+
+    final inherited = element.widget as MinInherited<T>;
     return inherited.notifier!;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: minimals_state_manager
 description: "A fastest, lightweight, high-performance, and boilerplate-free state management and dependency injection solution for Flutter."
 
-version: 2.1.7
+version: 2.2.0
 
 executables:
   min: min

--- a/test/extensions/min_provider_extensios_test.dart
+++ b/test/extensions/min_provider_extensios_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minimals_state_manager/minimals_state_manager.dart';
 
 /// Dummy class to act as our state manager for testing purposes.
-class TestController extends ChangeNotifier {
+class TestNotifier extends MinNotifier {
   int value = 0;
   void increment() {
     value++;
@@ -11,16 +11,26 @@ class TestController extends ChangeNotifier {
   }
 }
 
+class RegisteredNotifier extends ChangeNotifier {}
+
+class MissingNotifier extends MinNotifier {}
+
 void main() {
   group('ProviderExtension Tests', () {
+    /// {@template min_provider_extensions_test.watch_min_inherited}
+    /// **Test Target:** `watch` via `MinProvider`
+    ///
+    /// **Objective:** Verifies that [watch] correctly retrieves a notifier
+    /// from the single-provider [MinProvider] hierarchy.
+    /// {@endtemplate}
     testWidgets('watch should retrieve from MinInherited', (tester) async {
-      final controller = TestController();
+      final controller = TestNotifier();
 
       await tester.pumpWidget(
         MinProvider(
           create: () => controller,
           child: Builder(builder: (context) {
-            final found = context.watch<TestController>();
+            final found = context.watch<TestNotifier>();
             expect(found, controller);
             return Container();
           }),
@@ -28,14 +38,20 @@ void main() {
       );
     });
 
+    /// {@template min_provider_extensions_test.watch_multi_provider}
+    /// **Test Target:** `watch` via `MinMultiProvider`
+    ///
+    /// **Objective:** Verifies that [watch] correctly retrieves a notifier
+    /// from the `MinMultiProvider` registry.
+    /// {@endtemplate}
     testWidgets('watch should retrieve from MinMultiProvider', (tester) async {
-      final controller = TestController();
+      final controller = TestNotifier();
 
       await tester.pumpWidget(
         MinMultiProvider(
           create: [() => controller],
           child: Builder(builder: (context) {
-            final found = context.watch<TestController>();
+            final found = context.watch<TestNotifier>();
             expect(found, controller);
             return Container();
           }),
@@ -43,23 +59,35 @@ void main() {
       );
     });
 
+    /// {@template min_provider_extensions_test.watch_not_found}
+    /// **Test Target:** `watch` Not Found Error
+    ///
+    /// **Objective:** Assures that attempting to [watch] a notifier when no
+    /// provider is present in the tree throws an [Exception].
+    /// {@endtemplate}
     testWidgets('watch should throw exception when not found', (tester) async {
       await tester.pumpWidget(
         Builder(builder: (context) {
-          expect(() => context.watch<TestController>(), throwsException);
+          expect(() => context.watch<TestNotifier>(), throwsException);
           return Container();
         }),
       );
     });
 
+    /// {@template min_provider_extensions_test.read_min_inherited}
+    /// **Test Target:** `read` via `MinProvider`
+    ///
+    /// **Objective:** Verifies that [read] correctly retrieves a notifier
+    /// from the single-provider [MinProvider] hierarchy.
+    /// {@endtemplate}
     testWidgets('read should retrieve from MinInherited', (tester) async {
-      final controller = TestController();
+      final controller = TestNotifier();
 
       await tester.pumpWidget(
         MinProvider(
           create: () => controller,
           child: Builder(builder: (context) {
-            final found = context.read<TestController>();
+            final found = context.read<TestNotifier>();
             expect(found, controller);
             return Container();
           }),
@@ -67,14 +95,20 @@ void main() {
       );
     });
 
+    /// {@template min_provider_extensions_test.read_multi_provider}
+    /// **Test Target:** `read` via `MinMultiProvider`
+    ///
+    /// **Objective:** Verifies that [read] correctly retrieves a notifier
+    /// from the `MinMultiProvider` registry.
+    /// {@endtemplate}
     testWidgets('read should retrieve from MinMultiProvider', (tester) async {
-      final controller = TestController();
+      final controller = TestNotifier();
 
       await tester.pumpWidget(
         MinMultiProvider(
           create: [() => controller],
           child: Builder(builder: (context) {
-            final found = context.read<TestController>();
+            final found = context.read<TestNotifier>();
             expect(found, controller);
             return Container();
           }),
@@ -82,23 +116,55 @@ void main() {
       );
     });
 
+    /// {@template min_provider_extensions_test.read_not_found}
+    /// **Test Target:** `read` Not Found Error
+    ///
+    /// **Objective:** Assures that attempting to [read] a notifier when no
+    /// provider is present in the tree throws an [Exception].
+    /// {@endtemplate}
     testWidgets('read should throw exception when not found', (tester) async {
       await tester.pumpWidget(
         Builder(builder: (context) {
-          expect(() => context.read<TestController>(), throwsException);
+          expect(() => context.read<TestNotifier>(), throwsException);
           return Container();
         }),
       );
     });
 
-    testWidgets('read should throw exception when not found in MultiProvider',
+    /// {@template min_provider_extensions_test.read_missing_in_multi}
+    /// **Test Target:** `read` Missing Type in MultiProvider
+    ///
+    /// **Objective:** Verifies that requesting an unregistered type via [read]
+    /// within a `MinMultiProvider` throws the expected [Exception].
+    /// {@endtemplate}
+    testWidgets(
+        'Read should throw Exception if type is missing in MultiProvider',
         (tester) async {
-      // Testing the orElse branch of firstWhere in MultiProvider
       await tester.pumpWidget(
         MinMultiProvider(
-          create: [() => ChangeNotifier()],
+          create: [() => RegisteredNotifier()],
           child: Builder(builder: (context) {
-            expect(() => context.read<TestController>(), throwsException);
+            expect(() => context.read<MissingNotifier>(), throwsException);
+            return Container();
+          }),
+        ),
+      );
+    });
+
+    /// {@template min_provider_extensions_test.watch_missing_in_multi}
+    /// **Test Target:** `watch` Missing Type in MultiProvider
+    ///
+    /// **Objective:** Verifies that requesting an unregistered type via [watch]
+    /// within a `MinMultiProvider` tree also throws the expected [Exception].
+    /// {@endtemplate}
+    testWidgets(
+        'Watch should throw Exception if type is missing in MultiProvider',
+        (tester) async {
+      await tester.pumpWidget(
+        MinMultiProvider(
+          create: [() => RegisteredNotifier()],
+          child: Builder(builder: (context) {
+            expect(() => context.watch<MissingNotifier>(), throwsException);
             return Container();
           }),
         ),

--- a/test/observers/min_app_lifecycle_test.dart
+++ b/test/observers/min_app_lifecycle_test.dart
@@ -1,11 +1,13 @@
 import 'dart:ui';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minimals_state_manager/minimals_state_manager.dart';
 
-/// A concrete implementation of [AppLifecycleMixin] to verify callback execution.
-/// We call `super` inside overrides to ensure the mixin's default implementation is executed.
+/// A concrete implementation of [AppLifecycleMixin] used for testing purposes.
+///
+/// This class tracks which lifecycle methods have been invoked, allowing
+/// verification that the mixin correctly delegates calls from [WidgetsBindingObserver].
 class TestLifecycleController with AppLifecycleMixin {
   bool resumedCalled = false;
   bool inactiveCalled = false;
@@ -25,6 +27,12 @@ class TestLifecycleController with AppLifecycleMixin {
   bool pushRouteCalled = false;
   bool pushRouteInfoCalled = false;
   bool requestAppExitCalled = false;
+
+  // Back gesture tracking
+  bool startBackGestureCalled = false;
+  bool updateBackGestureCalled = false;
+  bool commitBackGestureCalled = false;
+  bool cancelBackGestureCalled = false;
 
   @override
   void onResumed() {
@@ -111,33 +119,54 @@ class TestLifecycleController with AppLifecycleMixin {
   }
 
   @override
+  bool onStartBackGesture(PredictiveBackEvent e) {
+    startBackGestureCalled = true;
+    return true;
+  }
+
+  @override
+  void onUpdateBackGestureProgress(PredictiveBackEvent e) {
+    updateBackGestureCalled = true;
+  }
+
+  @override
+  void onCommitBackGesture() {
+    commitBackGestureCalled = true;
+  }
+
+  @override
+  void onCancelBackGesture() {
+    cancelBackGestureCalled = true;
+  }
+
+  @override
   Future<bool> onPopRoute() async {
-    await super.onPopRoute();
     popRouteCalled = true;
     return true;
   }
 
   @override
   Future<bool> onPushRoute(String r) async {
-    await super.onPushRoute(r);
     pushRouteCalled = true;
     return true;
   }
 
   @override
   Future<bool> onPushRouteInformation(RouteInformation i) async {
-    await super.onPushRouteInformation(i);
     pushRouteInfoCalled = true;
     return true;
   }
 
   @override
   Future<AppExitResponse> onRequestAppExit() async {
-    await super.onRequestAppExit();
     requestAppExitCalled = true;
     return AppExitResponse.exit;
   }
 }
+
+class _DefaultLifecycleObserver with AppLifecycleMixin {}
+
+class _TestLifecycleObserver with AppLifecycleMixin {}
 
 void main() {
   group('AppLifecycleMixin Coverage Tests', () {
@@ -147,70 +176,162 @@ void main() {
       controller = TestLifecycleController();
     });
 
+    test('Should trigger default mixin implementations', () {
+      final defaultMixin = _DefaultLifecycleObserver();
+
+      expect(
+          defaultMixin.onStartBackGesture(PredictiveBackEvent.fromMap(const {
+            'touchOffset': [0.0, 0.0],
+            'progress': 0.0,
+            'swipeEdge': 0,
+          })),
+          isFalse); // O padrão retorna false
+
+      defaultMixin
+          .onUpdateBackGestureProgress(PredictiveBackEvent.fromMap(const {
+        'touchOffset': [0.0, 0.0],
+        'progress': 0.0,
+        'swipeEdge': 0,
+      }));
+
+      defaultMixin.onCommitBackGesture();
+      defaultMixin.onCancelBackGesture();
+    });
+
     test('Should trigger all lifecycle state changes and switch branches', () {
-      // By calling didChangeAppLifecycleState, we trigger the internal switch statement
-      controller.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      final states = [
+        AppLifecycleState.resumed,
+        AppLifecycleState.inactive,
+        AppLifecycleState.paused,
+        AppLifecycleState.hidden,
+        AppLifecycleState.detached,
+      ];
+
+      for (final state in states) {
+        controller.didChangeAppLifecycleState(state);
+      }
+
       expect(controller.resumedCalled, isTrue);
-
-      controller.didChangeAppLifecycleState(AppLifecycleState.inactive);
       expect(controller.inactiveCalled, isTrue);
-
-      controller.didChangeAppLifecycleState(AppLifecycleState.paused);
       expect(controller.pausedCalled, isTrue);
-
-      controller.didChangeAppLifecycleState(AppLifecycleState.hidden);
       expect(controller.hiddenCalled, isTrue);
-
-      controller.didChangeAppLifecycleState(AppLifecycleState.detached);
       expect(controller.detachedCalled, isTrue);
-
       expect(controller.lifecycleChangedCalled, isTrue);
     });
 
     test('Should trigger all system observer methods', () {
       controller.didHaveMemoryPressure();
-      expect(controller.memoryPressureCalled, isTrue);
-
       controller.didChangePlatformBrightness();
-      expect(controller.platformBrightnessCalled, isTrue);
-
       controller.didChangeLocales(null);
-      expect(controller.localesChangedCalled, isTrue);
-
       controller.didChangeAccessibilityFeatures();
-      expect(controller.accessibilityChangedCalled, isTrue);
-
       controller.didChangeMetrics();
-      expect(controller.metricsChangedCalled, isTrue);
-
       controller.didChangeTextScaleFactor();
-      expect(controller.textScaleFactorCalled, isTrue);
-
+      controller.handleStatusBarTap();
       controller.didChangeViewFocus(const ViewFocusEvent(
           direction: ViewFocusDirection.forward,
           viewId: 1,
           state: ViewFocusState.focused));
-      expect(controller.viewFocusChangedCalled, isTrue);
 
-      controller.handleStatusBarTap();
+      expect(controller.memoryPressureCalled, isTrue);
+      expect(controller.platformBrightnessCalled, isTrue);
+      expect(controller.localesChangedCalled, isTrue);
+      expect(controller.accessibilityChangedCalled, isTrue);
+      expect(controller.metricsChangedCalled, isTrue);
+      expect(controller.textScaleFactorCalled, isTrue);
       expect(controller.statusBarTapCalled, isTrue);
+      expect(controller.viewFocusChangedCalled, isTrue);
     });
 
-    test('Should trigger all navigation observer methods', () async {
-      expect(await controller.didPopRoute(), isTrue);
-      expect(controller.popRouteCalled, isTrue);
+    test('Should trigger all predictive back gesture methods', () {
+      final event = PredictiveBackEvent.fromMap(const {
+        'touchOffset': [0.0, 0.0],
+        'progress': 0.0,
+        'swipeEdge': 0,
+      });
 
-      expect(await controller.didPushRoute('test'), isTrue);
-      expect(controller.pushRouteCalled, isTrue);
+      expect(controller.handleStartBackGesture(event), isTrue);
+      expect(controller.startBackGestureCalled, isTrue);
 
-      expect(
-          await controller
-              .didPushRouteInformation(RouteInformation(uri: Uri.parse('/'))),
-          isTrue);
-      expect(controller.pushRouteInfoCalled, isTrue);
+      controller.handleUpdateBackGestureProgress(event);
+      expect(controller.updateBackGestureCalled, isTrue);
 
-      expect(await controller.didRequestAppExit(), AppExitResponse.exit);
-      expect(controller.requestAppExitCalled, isTrue);
+      controller.handleCommitBackGesture();
+      expect(controller.commitBackGestureCalled, isTrue);
+
+      controller.handleCancelBackGesture();
+      expect(controller.cancelBackGestureCalled, isTrue);
+    });
+
+    group('AppLifecycleMixin Lifecycle & Routing', () {
+      /// {@template min_app_lifecycle_test.custom_implementation}
+      /// **Test Target:** Custom `AppLifecycleMixin` Implementation
+      ///
+      /// **Objective:** Verifies that a class overriding `AppLifecycleMixin`
+      /// methods correctly executes the custom logic provided by the controller.
+      /// {@endtemplate}
+      test('Should trigger all navigation observer methods', () async {
+        // Assert: Verify that the overridden methods in 'controller' are called
+        // and return the expected values.
+        expect(await controller.didPopRoute(), isTrue);
+        expect(controller.popRouteCalled, isTrue);
+
+        expect(await controller.didPushRoute('test'), isTrue);
+        expect(controller.pushRouteCalled, isTrue);
+
+        expect(
+          await controller.didPushRouteInformation(
+            RouteInformation(uri: Uri.parse('/')),
+          ),
+          isTrue,
+        );
+        expect(controller.pushRouteInfoCalled, isTrue);
+
+        expect(await controller.didRequestAppExit(), AppExitResponse.exit);
+        expect(controller.requestAppExitCalled, isTrue);
+      });
+
+      /// {@template min_app_lifecycle_test.default_implementation}
+      /// **Test Target:** `AppLifecycleMixin` Default Fallback
+      ///
+      /// **Objective:** Verifies that when a class uses [AppLifecycleMixin] without
+      /// overriding its methods, it correctly returns the framework-defined
+      /// default values for route handling and app exit requests.
+      ///
+      /// This test specifically covers the lines in the mixin that provide
+      /// default async implementations.
+      /// {@endtemplate}
+      test(
+          'Should return default values when no custom implementation is provided',
+          () async {
+        // Arrange: Instantiate the concrete helper class that uses the mixin
+        final observer = _TestLifecycleObserver();
+
+        // Act & Assert: Verify default route pop handling (returns false)
+        expect(await observer.onPopRoute(), isFalse);
+
+        // Act & Assert: Verify default route push handling (returns false)
+        expect(await observer.onPushRoute('/test'), isFalse);
+
+        // Act & Assert: Verify default route information handling (returns false)
+        expect(
+            await observer
+                .onPushRouteInformation(RouteInformation(uri: Uri.parse('/'))),
+            isFalse);
+
+        // Act & Assert: Verify default app exit behavior (returns AppExitResponse.exit)
+        expect(await observer.onRequestAppExit(), AppExitResponse.exit);
+      });
+    });
+
+    /// {@template min_app_lifecycle_test.constructor}
+    /// **Test Target:** `AppLifecycleMixin` Constructor
+    ///
+    /// **Objective:** Instantiates a class using the mixin to ensure the
+    /// constructor is covered by the test suite.
+    /// {@endtemplate}
+    test('Should instantiate AppLifecycleMixin via concrete class', () {
+      final observer = _TestLifecycleObserver();
+      expect(observer, isNotNull);
     });
   });
 }

--- a/test/providers/min_multi_provider_test.dart
+++ b/test/providers/min_multi_provider_test.dart
@@ -15,9 +15,19 @@ class CartNotifier extends ChangeNotifier {}
 
 class SettingsNotifier extends ChangeNotifier {}
 
+class RegisteredNotifier extends MinNotifier {}
+
+class MissingNotifier extends ChangeNotifier {}
+
 void main() {
   group('MinMultiProvider Tests', () {
-    testWidgets('Should inject multiple controllers and support static access',
+    /// {@template min_multi_provider_test.injection}
+    /// **Test Target:** `MinMultiProvider` Injection
+    ///
+    /// **Objective:** Verifies that multiple notifiers are correctly injected
+    /// and accessible via static [read] calls.
+    /// {@endtemplate}
+    testWidgets('Should inject multiple notifier and support static access',
         (tester) async {
       final n1 = MultiNotifier();
       final n2 = CartNotifier();
@@ -27,7 +37,6 @@ void main() {
         MinMultiProvider(
           create: [() => n1, () => n2, () => n3],
           child: Builder(builder: (context) {
-            // Agora cada busca é específica e inequívoca
             final read1 = MinMultiProvider.read<MultiNotifier>(context);
             final read2 = MinMultiProvider.read<CartNotifier>(context);
             final read3 = MinMultiProvider.read<SettingsNotifier>(context);
@@ -43,6 +52,12 @@ void main() {
       expect(n1.onInitCalled, isTrue);
     });
 
+    /// {@template min_multi_provider_test.watch}
+    /// **Test Target:** `MinMultiProvider.watch`
+    ///
+    /// **Objective:** Verifies that the provider correctly exposes notifiers
+    /// through the watch method.
+    /// {@endtemplate}
     testWidgets('Watch should work for MultiProvider', (tester) async {
       final n1 = MultiNotifier();
 
@@ -58,6 +73,12 @@ void main() {
       );
     });
 
+    /// {@template min_multi_provider_test.missing_provider}
+    /// **Test Target:** Missing Provider Error
+    ///
+    /// **Objective:** Assures that calling read/watch without an ancestor
+    /// [MinMultiProvider] throws a [FlutterError].
+    /// {@endtemplate}
     testWidgets('Should throw error when provider missing', (tester) async {
       await tester.pumpWidget(Builder(builder: (context) {
         expect(() => MinMultiProvider.read<MultiNotifier>(context),
@@ -68,14 +89,44 @@ void main() {
       }));
     });
 
-    testWidgets('Should throw error when type not found in MultiProvider',
+    /// {@template min_multi_provider_test.read_missing_type}
+    /// **Test Target:** Missing Type Error (Read)
+    ///
+    /// **Objective:** Verifies that requesting a non-existent type via [read]
+    /// throws a clear [FlutterError].
+    /// {@endtemplate}
+    testWidgets('Read should throw FlutterError if notifier type is missing',
         (tester) async {
       await tester.pumpWidget(
         MinMultiProvider(
-          create: [() => ChangeNotifier()],
+          create: [() => RegisteredNotifier()],
           child: Builder(builder: (context) {
-            expect(() => MinMultiProvider.read<MultiNotifier>(context),
-                throwsFlutterError);
+            expect(
+              () => MinMultiProvider.read<MissingNotifier>(context),
+              throwsA(isA<FlutterError>()),
+            );
+            return Container();
+          }),
+        ),
+      );
+    });
+
+    /// {@template min_multi_provider_test.watch_missing_type}
+    /// **Test Target:** Missing Type Error (Watch)
+    ///
+    /// **Objective:** Verifies that requesting a non-existent type via [watch]
+    /// throws a clear [FlutterError].
+    /// {@endtemplate}
+    testWidgets('Watch should throw FlutterError if notifier type is missing',
+        (tester) async {
+      await tester.pumpWidget(
+        MinMultiProvider(
+          create: [() => RegisteredNotifier()],
+          child: Builder(builder: (context) {
+            expect(
+              () => MinMultiProvider.watch<MissingNotifier>(context),
+              throwsA(isA<FlutterError>()),
+            );
             return Container();
           }),
         ),

--- a/test/providers/min_provider_test.dart
+++ b/test/providers/min_provider_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minimals_state_manager/minimals_state_manager.dart';
 
-/// Dummy class for testing [MinProvider] lifecycle and state.
+/// A dummy [MinNotifier] implementation for testing lifecycle and state updates.
 class TestNotifier extends MinNotifier {
   bool onInitCalled = false;
   bool onReadyCalled = false;
@@ -33,7 +33,13 @@ class TestNotifier extends MinNotifier {
 
 void main() {
   group('MinProvider Tests', () {
-    testWidgets('Should execute lifecycle hooks and inject controller',
+    /// {@template min_provider_test.lifecycle}
+    /// **Test Target:** `MinProvider` Lifecycle
+    ///
+    /// **Objective:** Verifies that `onInit` and `onReady` are called correctly
+    /// when the provider is added to the widget tree.
+    /// {@endtemplate}
+    testWidgets('Should execute lifecycle hooks and inject notifier',
         (tester) async {
       final notifier = TestNotifier();
 
@@ -49,11 +55,16 @@ void main() {
       );
 
       expect(notifier.onInitCalled, isTrue);
-      // Wait for postFrameCallback
+      // Wait for postFrameCallback to trigger onReady
       await tester.pump();
       expect(notifier.onReadyCalled, isTrue);
     });
 
+    /// {@template min_provider_test.watch}
+    /// **Test Target:** `MinProvider.watch`
+    ///
+    /// **Objective:** Verifies that widgets rebuild when the state changes.
+    /// {@endtemplate}
     testWidgets('Should watch for changes and rebuild', (tester) async {
       final notifier = TestNotifier();
       int rebuilds = 0;
@@ -75,12 +86,16 @@ void main() {
       expect(rebuilds, 2);
     });
 
-    testWidgets('Should dispose controller when provider is removed',
+    /// {@template min_provider_test.dispose}
+    /// **Test Target:** `MinProvider` Disposal
+    ///
+    /// **Objective:** Verifies that the notifier is disposed when the provider
+    /// is removed from the tree.
+    /// {@endtemplate}
+    testWidgets('Should dispose notifier when provider is removed',
         (tester) async {
-      // Arrange: Create your controller
       final notifier = TestNotifier();
 
-      // Act: Mount the provider in the tree
       await tester.pumpWidget(
         MinProvider(
           create: () => notifier,
@@ -88,25 +103,42 @@ void main() {
         ),
       );
 
-      // Verify it's mounted
       expect(find.byType(Container), findsOneWidget);
 
-      // Act: Force removal by pumping an empty Container
-      // This triggers the dispose() method in the State class of MinProvider
+      // Force removal
       await tester.pumpWidget(Container());
 
-      // Assert: Check if the controller was disposed
       expect(notifier.disposeCalled, isTrue);
     });
 
-    testWidgets('Read/Watch should throw error if not found', (tester) async {
-      await tester.pumpWidget(Builder(builder: (context) {
-        expect(() => MinProvider.read<TestNotifier>(context),
-            throwsAssertionError);
-        expect(() => MinProvider.watch<TestNotifier>(context),
-            throwsAssertionError);
-        return Container();
-      }));
+    /// {@template min_provider_test.error_handling}
+    /// **Test Target:** `MinProvider` Error Handling
+    ///
+    /// **Objective:** Verifies that calling `read` or `watch` without a parent
+    /// provider throws a clear [FlutterError].
+    /// {@endtemplate}
+    testWidgets('Read/Watch should throw FlutterError if not found',
+        (tester) async {
+      late BuildContext capturedContext;
+
+      await tester.pumpWidget(
+        Builder(builder: (context) {
+          capturedContext = context;
+          return Container();
+        }),
+      );
+
+      // Verify read error
+      expect(
+        () => MinProvider.read<TestNotifier>(capturedContext),
+        throwsA(isA<FlutterError>()),
+      );
+
+      // Verify watch error
+      expect(
+        () => MinProvider.watch<TestNotifier>(capturedContext),
+        throwsA(isA<FlutterError>()),
+      );
     });
   });
 }

--- a/test/services/min_service_test.dart
+++ b/test/services/min_service_test.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:minimals_state_manager/min_services.dart'; // Ajuste o import para o seu pacote
+import 'package:minimals_state_manager/min_services.dart';
+
+// --- Test Helper Classes ---
 
 abstract class AuthService {}
 
@@ -9,20 +12,30 @@ abstract class ThemeService {}
 
 class ThemeServiceImpl implements ThemeService {}
 
+/// Helper class to verify that [dispose] is correctly called.
+class TestChangeNotifier extends ChangeNotifier {
+  bool disposed = false;
+
+  @override
+  void dispose() {
+    disposed = true;
+    super.dispose();
+  }
+}
+
 void main() {
   late MinService min;
 
   setUp(() {
     min = MinService.instance;
-    min.reset(); // reset di
+    min.reset();
   });
 
   /// {@template min_service_test.registration_and_resolution}
   /// **Test Target:** `MinService` Registration & Type Resolution
   ///
   /// **Objective:** Verifies if a classic singleton and a lazy singleton
-  /// can be registered cleanly and always return the exact same instance pointer
-  /// upon successive retrievals, validating the core O(1) locator map.
+  /// can be registered cleanly and return the exact same instance pointer.
   /// {@endtemplate}
   test('Should register and resolve singletons and lazy singletons accurately',
       () {
@@ -32,8 +45,7 @@ void main() {
 
     // Act
     final theme1 = min.get<ThemeService>();
-    final theme2 =
-        min<ThemeService>(); // Testando a chamada direta via callable class
+    final theme2 = min<ThemeService>();
     final auth1 = min.get<AuthService>();
     final auth2 = min.get<AuthService>();
 
@@ -47,30 +59,126 @@ void main() {
   /// {@template min_service_test.existence_and_destruction}
   /// **Test Target:** `MinService` Lifecycle Queries & Scoped Destruction
   ///
-  /// **Objective:** Assures that `exists<T>()` accurately reports structural registration
-  /// state and verifies that invoking `destroy<T>()` completely unloads the instance,
-  /// allowing subsequent factory re-allocation without container leaks.
+  /// **Objective:** Assures that `exists<T>()` reports accurately and
+  /// `destroy<T>()` unloads the instance properly.
   /// {@endtemplate}
   test(
       'Should accurately check existence and destroy specific service allocations',
       () {
-    // Arrange
     min.registerSingleton<ThemeService>(ThemeServiceImpl());
     expect(min.exists<ThemeService>(), isTrue);
     expect(min.exists<AuthService>(), isFalse);
 
-    // Act
     final firstThemeInstance = min.get<ThemeService>();
     min.destroy<ThemeService>();
 
-    // Assert
     expect(min.exists<ThemeService>(), isFalse);
 
-    // Re-register to check if it behaves as a fresh slot
     min.registerSingleton<ThemeService>(ThemeServiceImpl());
     final secondThemeInstance = min.get<ThemeService>();
 
     expect(identityHashCode(firstThemeInstance),
         isNot(equals(identityHashCode(secondThemeInstance))));
+  });
+
+  /// {@template min_service_test.error_handling}
+  /// **Test Target:** `MinService` Assertions
+  ///
+  /// **Objective:** Verifies that requesting an unregistered service throws
+  /// the expected assertion error.
+  /// {@endtemplate}
+  test('Should throw an assertion error when resolving an unregistered type',
+      () {
+    expect(() => min.get<String>(), throwsAssertionError);
+  });
+
+  /// {@template min_service_test.disposable_handling}
+  /// **Test Target:** `MinService` Disposal Logic
+  ///
+  /// **Objective:** Verifies that instances implementing ChangeNotifier
+  /// are correctly disposed during destruction.
+  /// {@endtemplate}
+  test('Should call dispose() on ChangeNotifier instances', () {
+    final disposableService = TestChangeNotifier();
+    min.registerSingleton<TestChangeNotifier>(disposableService);
+
+    expect(disposableService.disposed, isFalse);
+
+    // This triggers the lines 92 and 110 of your MinService
+    min.destroy<TestChangeNotifier>();
+
+    expect(disposableService.disposed, isTrue);
+  });
+
+  /// {@template min_service_test.deep_cleanup}
+  /// **Test Target:** `MinService` Deep Cleanup
+  ///
+  /// **Objective:** Verifies that destruction correctly removes both active
+  /// instances and lazy builders, and ensures that destroyAll processes
+  /// all registered ChangeNotifier instances.
+  /// {@endtemplate}
+  test(
+      'Should fully clear builders and dispose all change notifiers on destruction',
+      () {
+    // 1. Arrange: Register a lazy singleton and a singleton ChangeNotifier
+    min.registerLazySingleton<AuthService>(() => AuthServiceImpl());
+    final disposable = TestChangeNotifier();
+    min.registerSingleton<TestChangeNotifier>(disposable);
+
+    // 2. Act: Destroy the lazy singleton
+    // This covers line 102: _builders.remove(type)
+    min.destroy<AuthService>();
+
+    // 3. Act: Use destroyAll for the ChangeNotifier
+    // This covers line 110: instance.dispose()
+    min.destroyAll();
+
+    // 4. Assert
+    expect(min.exists<AuthService>(), isFalse);
+    expect(disposable.disposed, isTrue);
+  });
+
+  /// {@template min_service_test.builder_removal}
+  /// **Test Target:** `MinService.destroy` - Builder Removal
+  ///
+  /// **Objective:** Verifies that when `destroy<T>()` is called, the corresponding
+  /// builder function is removed from the internal `_builders` map.
+  /// {@endtemplate}
+  test('Should remove lazy builder from _builders map when destroy is called',
+      () {
+    // Arrange: Register a lazy singleton
+    min.registerLazySingleton<AuthService>(() => AuthServiceImpl());
+
+    // Act: Destroy the service.
+    // This explicitly triggers the 'if (_builders.containsKey(type))' block
+    // and the '_builders.remove(type)' line (Line 102).
+    min.destroy<AuthService>();
+
+    // Assert: Verify builder is gone by trying to resolve it (should throw error)
+    expect(() => min.get<AuthService>(), throwsAssertionError);
+  });
+
+  /// {@template min_service_test.destroy_all_notifiers}
+  /// **Test Target:** `MinService.destroyAll` - Deep Disposal
+  ///
+  /// **Objective:** Ensures that `destroyAll()` successfully iterates through all
+  /// instances and invokes `dispose()` on any registered `ChangeNotifier`.
+  /// {@endtemplate}
+  test('Should call dispose on all ChangeNotifiers during destroyAll', () {
+    // Arrange: Register multiple ChangeNotifier instances to ensure the loop
+    // in destroyAll (Line 108) runs and executes dispose (Line 110).
+    final notifier1 = TestChangeNotifier();
+    final notifier2 = TestChangeNotifier();
+
+    min.registerSingleton<TestChangeNotifier>(notifier1);
+    // Registering as the base class to test the 'is ChangeNotifier' check
+    min.registerSingleton<ChangeNotifier>(notifier2);
+
+    // Act: Invoke global destruction
+    min.destroyAll();
+
+    // Assert: Verify that both notifiers were properly disposed of
+    expect(notifier1.disposed, isTrue);
+    expect(notifier2.disposed, isTrue);
   });
 }

--- a/test/state/min_notifier_test.dart
+++ b/test/state/min_notifier_test.dart
@@ -44,6 +44,25 @@ class TestAsyncCrashNotifier extends MinNotifier {
 }
 
 void main() {
+  /// {@template min_notifier_test.disposal_status}
+  /// **Test Target:** `MinNotifier.isDisposed`
+  ///
+  /// **Objective:** Verifies that the internal disposal state is correctly tracked
+  /// by the `isDisposed` getter throughout the lifecycle.
+  /// {@endtemplate}
+  test('Should accurately reflect disposal status via isDisposed getter', () {
+    final notifier = TestMutationNotifier();
+
+    // Assert: Check initial state
+    expect(notifier.isDisposed, isFalse);
+
+    // Act: Dispose the notifier
+    notifier.dispose();
+
+    // Assert: Check post-disposal state
+    expect(notifier.isDisposed, isTrue);
+  });
+
   /// {@template min_notifier_test.update_mutation}
   /// **Test Target:** `MinNotifier.update` Atomic Mutation Helper
   ///
@@ -72,7 +91,7 @@ void main() {
   /// **Test Target:** `MinNotifier` Memory Crash & Async Ghost Protection
   ///
   /// **Objective:** Validates the exclusive async safety guard. If an asynchronous process
-  /// concludes *after* the controller is systematically disposed of, the notification must
+  /// concludes *after* the notifier is systematically disposed of, the notification must
   /// be aborted safely, preventing the classic Flutter 'notifyListeners called after dispose' memory crash.
   /// {@endtemplate}
   test(

--- a/test/widget/min_selector_test.dart
+++ b/test/widget/min_selector_test.dart
@@ -283,5 +283,52 @@ void main() {
       expect(find.text('User: Kauê | Whatever: 1'), findsOneWidget);
       expect(buildCount, 2);
     }, variant: TargetPlatformVariant.all());
+
+    // ==========================================
+    // 6. 6. LIFECYCLE & EDGE CASES
+    // ==========================================
+    testWidgets(
+        'didUpdateWidget should update listeners when the notifier instance changes',
+        (tester) async {
+      // Use o seu TestNotifier que já está definido no arquivo
+      final notifier1 = TestNotifier();
+      final notifier2 = TestNotifier();
+
+      await tester.pumpWidget(
+        $<TestNotifier, int>(
+          // Ou o nome da sua classe se for diferente
+          notifier: notifier1,
+          selector: (n) => n.whatever,
+          builder: (context, value) => Container(),
+        ),
+      );
+
+      await tester.pumpWidget(
+        $<TestNotifier, int>(
+          notifier: notifier2,
+          selector: (n) => n.whatever,
+          builder: (context, value) => Container(),
+        ),
+      );
+
+      expect(find.byType(Container), findsOneWidget);
+
+      // Force didUpdateWidget by changing the notifier instance
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(builder: (context) {
+              return $<TestNotifier, int>(
+                notifier: notifier2,
+                selector: (n) => n.whatever,
+                builder: (context, val) => Text('$val'),
+              );
+            }),
+          ),
+        ),
+      );
+
+      expect(find.text('0'), findsOneWidget);
+    }, variant: TargetPlatformVariant.all());
   });
 }


### PR DESCRIPTION
# 2.2.0
- Add missing dart docs to get 100% covarage of the dart docs in pub score (before was 91.5%)
- Generate dart doc api
- Add missing tests and get 100% tests coverage (before was 89%)
- Handle errors to `MinProvider.read` and `.watch`
